### PR TITLE
Use terminal graphics by default (instead of window)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ struct Args {
     app: AppName,
 
     /// How to run the game
-    #[arg(short, long, value_enum, default_value = "window")]
+    #[arg(short, long, value_enum, default_value = "terminal")]
     runtime: Runtime,
 
     /// In the terminal, how many characters wide should each game cell be


### PR DESCRIPTION
The terminal runtime puts less requiements on the user's environment so it makes sense to use it as a default when no explicit choice has been made.